### PR TITLE
Removed deprecated constuctor in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ public class Summary {
 
 	public static void main(String[] args) {
 
-	Context ctx = new ContextBuilder("https://api-fxpractice.oanda.com")
+		Context ctx = new ContextBuilder("https://api-fxpractice.oanda.com")
 			.setToken("<TOKEN>")
 			.setApplication("DemoApp")
 			.build();

--- a/README.md
+++ b/README.md
@@ -119,15 +119,18 @@ Edit the Summary.java file to contain the following:
 
 ```
 import com.oanda.v20.Context;
+import com.oanda.v20.ContextBuilder;
 import com.oanda.v20.account.AccountID;
 import com.oanda.v20.account.AccountSummary;
 
 public class Summary {
 
 	public static void main(String[] args) {
-		Context ctx = new Context(
-				"https://api-fxpractice.oanda.com",
-				"<TOKEN>");
+
+	Context ctx = new ContextBuilder("https://api-fxpractice.oanda.com")
+			.setToken("<TOKEN>")
+			.setApplication("DemoApp")
+			.build();
 
 		try {
 			AccountSummary summary = ctx.account.summary(


### PR DESCRIPTION
The constructor `Context(String, String)` is deprecated. Refactored example code to `ContextBuilder`.