### PR TITLE
 Context: check required constructor parameters aren't null 

### DIFF
--- a/src/com/oanda/v20/Context.java
+++ b/src/com/oanda/v20/Context.java
@@ -90,6 +90,7 @@ public class Context {
         this.httpClient = Objects.requireNonNull(httpClient, "httpClient can not be null");
 
         Objects.requireNonNull(application, "application can not be null");
+        Objects.requireNonNull(datetimeFormat, "datetimeFormat can not be null");
 
         String extensions = null;
 

--- a/src/com/oanda/v20/Context.java
+++ b/src/com/oanda/v20/Context.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Objects;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -84,9 +85,11 @@ public class Context {
         AcceptDatetimeFormat datetimeFormat,
         HttpClient httpClient
     ) {
-        this.uri = uri;
-        this.token = token;
-        this.httpClient = httpClient;
+        this.uri = Objects.requireNonNull(uri, "uri can not be null");
+        this.token = Objects.requireNonNull(token, "token can not be null");
+        this.httpClient = Objects.requireNonNull(httpClient, "httpClient can not be null");
+
+        Objects.requireNonNull(application, "application can not be null");
 
         String extensions = null;
 


### PR DESCRIPTION
This PR introduces a null parameter check in the constructor. Especially when the `ContextBuilder` is used, it easy to forget required parameters (e.g., application) and the resulting Exception does not point out the missing parameter. With this patch, a customized `NullPointerException` is thrown.

== Old == 

```java
Exception in thread "main" java.lang.NullPointerException
	at com.oanda.v20.Context.<init>(Context.java:93)
	at com.oanda.v20.ContextBuilder.build(ContextBuilder.java:100)
```

== New == 
```java
Exception in thread "main" java.lang.NullPointerException : application can not be null
	at com.oanda.v20.Context.<init>(Context.java:92)
	at com.oanda.v20.ContextBuilder.build(ContextBuilder.java:100)
```