### PR TITLE
Adds missing required parameter accountID to the PricingCandlesRequest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oanda.v20</groupId>
   <artifactId>v20</artifactId>
-  <version>3.0.25</version>
+  <version>3.0.26</version>
 
   <packaging>jar</packaging>
 

--- a/src/com/oanda/v20/pricing/PricingCandlesRequest.java
+++ b/src/com/oanda/v20/pricing/PricingCandlesRequest.java
@@ -3,6 +3,7 @@ package com.oanda.v20.pricing;
 import java.math.BigDecimal;
 
 import com.oanda.v20.Request;
+import com.oanda.v20.account.AccountID;
 import com.oanda.v20.instrument.CandlestickGranularity;
 import com.oanda.v20.instrument.WeeklyAlignment;
 import com.oanda.v20.primitives.DateTime;
@@ -21,7 +22,8 @@ public class PricingCandlesRequest extends Request {
      * <p>
      * @param instrument Name of the Instrument
      */
-    public PricingCandlesRequest(InstrumentName instrument) {
+    public PricingCandlesRequest(AccountID accountID, InstrumentName instrument) {
+        this.setPathParam("accountID", accountID);
         this.setPathParam("instrument", instrument);
 
     }

--- a/src/com/oanda/v20/pricing/PricingContext.java
+++ b/src/com/oanda/v20/pricing/PricingContext.java
@@ -199,10 +199,11 @@ public class PricingContext {
      * @see RequestException
      * @see ExecuteException
      */
-    public PricingCandlesResponse candles(InstrumentName instrument)
+
+    public PricingCandlesResponse candles(AccountID accountID, InstrumentName instrument)
         throws RequestException, ExecuteException
     {
-        PricingCandlesRequest request = new PricingCandlesRequest(instrument);
+        PricingCandlesRequest request = new PricingCandlesRequest(accountID, instrument);
         return candles(request);
     }
 


### PR DESCRIPTION
It is a fix for issue #12 which I encountered as well. During the `/v3/accounts/{accountID}/instruments/{instrument}/candles` call that is initiated by the `PricingContext#candles` method, an exception is thrown and the request fails as the required field `accountID` is not provided.